### PR TITLE
Removing erroneous hook constructor arg from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ app.configure( function() {
 	// ...
 
 	var h = hook(									// initialize a cartero hook
-		path.join( __dirname, "views" ),			// views directory
 		path.join( __dirname, "static/assets" ),	// output directory
 		{ outputDirUrl : 'assets/' }				// output directory base url
 	);


### PR DESCRIPTION
Unless I'm mistaken, the constructor arg for the hook in the example shouldn't be there (I'm just looking at the latest version of the hook library).  If I'm correct, this also needs updated in the blog tutorial: http://www.jslifeandlove.org/intro-to-cartero/
